### PR TITLE
Removing polyglot from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ numpy<1.17.0; python_version < '3.0'
 numpy>=1.16.0; python_version >= '3.0'
 pandas<0.25.0; python_version < '3.0'
 pandas>=0.25.0; python_version >= '3.0'
-polyglot>=16.7.4
 pycparser>=2.20
 python-dateutil>=2.6.0
 python-levenshtein>=0.12.0


### PR DESCRIPTION
We were playing around with polyglot a while back but ultimately didn't release any code that uses it, so we can safely remove it from the requirements